### PR TITLE
Increase memory limit to 512MB

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -2,4 +2,4 @@
 applications:
 - name: sample-aspnetcore-helloworld
   random-route: true
-  memory: 256M
+  memory: 512M


### PR DESCRIPTION
Increasing the memory limit to 512MB to avoid intermittent issues that some users are experiencing.
