### PR TITLE
Use AppContext to get base path

### DIFF
--- a/src/WebApplication/Program.cs
+++ b/src/WebApplication/Program.cs
@@ -1,5 +1,5 @@
-﻿using System.IO;
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
+using System;
 
 namespace WebApplication
 {
@@ -10,7 +10,7 @@ namespace WebApplication
             var host = new WebHostBuilder()
                 .UseKestrel()
                 .UseStartup<Startup>()
-                .UseContentRoot(Directory.GetCurrentDirectory())
+                .UseContentRoot(AppContext.BaseDirectory)
                 .Build();
             host.Run();
         }

--- a/src/WebApplication/Startup.cs
+++ b/src/WebApplication/Startup.cs
@@ -11,6 +11,7 @@ public class Startup
     public Startup(IHostingEnvironment env)
     {
         var builder = new ConfigurationBuilder()
+            .SetBasePath(env.ContentRootPath)
             .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
             .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true)
             .AddEnvironmentVariables();

--- a/src/WebApplication/WebApplication.csproj
+++ b/src/WebApplication/WebApplication.csproj
@@ -19,7 +19,7 @@
 
   <Target Name="AddWwwRoot" BeforeTargets="AssignTargetPaths" DependsOnTargets="BeforeBuild;BeforePublish">
     <ItemGroup>
-      <Content Include="wwwroot\**">
+      <Content Include="wwwroot\**;**\*.cshtml">
         <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       </Content>
     </ItemGroup>


### PR DESCRIPTION
- Fix debugging in VS Code
  - Always copy views to output folder
  - Use AppContext.BaseDirectory to set ContentRoot to allow running from any folder